### PR TITLE
Document new OpenAPI spec locations for FountainApps

### DIFF
--- a/Packages/FountainApps/Package.swift
+++ b/Packages/FountainApps/Package.swift
@@ -61,7 +61,8 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "X509", package: "swift-certificates"),
                 "Yams"
-            ]
+            ],
+            exclude: ["README.md"]
         ),
         .executableTarget(
             name: "tools-factory-server",
@@ -79,7 +80,8 @@ let package = Package(
                 .product(name: "FountainRuntime", package: "FountainCore"),
                 .product(name: "ToolServerService", package: "FountainServiceKit-ToolServer"),
                 .product(name: "LauncherSignature", package: "FountainCore")
-            ]
+            ],
+            exclude: ["README.md"]
         ),
         .executableTarget(
             name: "planner-server",
@@ -146,21 +148,24 @@ let package = Package(
             name: "publishing-frontend",
             dependencies: [
                 .product(name: "PublishingFrontend", package: "FountainGatewayKit")
-            ]
+            ],
+            exclude: ["README.md"]
         ),
         .executableTarget(
             name: "tutor-dashboard",
             dependencies: [
                 .product(name: "TutorDashboard", package: "FountainAPIClients"),
                 .product(name: "SwiftCursesKit", package: "swiftcurseskit")
-            ]
+            ],
+            exclude: ["README.md"]
         ),
         .executableTarget(
             name: "FountainLauncherUI",
             dependencies: [
                 .product(name: "SecretStore", package: "swift-secretstore")
             ],
-            path: "Sources/FountainLauncherUI"
+            path: "Sources/FountainLauncherUI",
+            exclude: ["README.md"]
         ),
         .testTarget(
             name: "FountainLauncherUITests",

--- a/Packages/FountainApps/Sources/FountainLauncherUI/README.md
+++ b/Packages/FountainApps/Sources/FountainLauncherUI/README.md
@@ -1,0 +1,21 @@
+# Fountain Launcher UI
+
+`FountainLauncherUI` is a macOS app that wraps the control-plane launcher scripts. It verifies the workspace layout, manages secrets in the keychain, and provides live status/console output for all Fountain services.
+
+## Features
+
+- Validates that the selected repository contains `Packages/FountainSpecCuration/openapi` and `Scripts/` assets before launching.
+- Starts/stops the control plane via the bundled shell scripts and tails logs inside the app.
+- Provides quick access to environment variables (`OPENAI_API_KEY`, `FOUNTAINSTORE_*`) and exports sanitized reports.
+
+## Usage
+
+Build and run via Xcode or SwiftPM:
+
+```bash
+open Packages/FountainApps/Sources/FountainLauncherUI
+# or
+swift run --package-path Packages/FountainApps FountainLauncherUI
+```
+
+Because the app targets macOS, a GUI environment is required.

--- a/Packages/FountainApps/Sources/baseline-awareness-server/README.md
+++ b/Packages/FountainApps/Sources/baseline-awareness-server/README.md
@@ -1,4 +1,4 @@
 # Baseline Awareness Service
 
-OpenAPI spec: [`openapi/v1/baseline-awareness.yml`](../../openapi/v1/baseline-awareness.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/baseline-awareness.yml`](../../../FountainSpecCuration/openapi/v1/baseline-awareness.yml)
 

--- a/Packages/FountainApps/Sources/bootstrap-server/README.md
+++ b/Packages/FountainApps/Sources/bootstrap-server/README.md
@@ -1,4 +1,4 @@
 # Bootstrap Service
 
-OpenAPI spec: [`openapi/v1/bootstrap.yml`](../../openapi/v1/bootstrap.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/bootstrap.yml`](../../../FountainSpecCuration/openapi/v1/bootstrap.yml)
 

--- a/Packages/FountainApps/Sources/function-caller-server/README.md
+++ b/Packages/FountainApps/Sources/function-caller-server/README.md
@@ -1,4 +1,4 @@
 # Function Caller Service
 
-OpenAPI spec: [`openapi/v1/function-caller.yml`](../../openapi/v1/function-caller.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/function-caller.yml`](../../../FountainSpecCuration/openapi/v1/function-caller.yml)
 

--- a/Packages/FountainApps/Sources/gateway-server/README.md
+++ b/Packages/FountainApps/Sources/gateway-server/README.md
@@ -1,0 +1,31 @@
+# Gateway Server
+
+The Gateway server is the control-plane entry point that authenticates requests, enforces policy, orchestrates LLM personas, and routes traffic to downstream Fountain services. The executable composes plugins from `FountainGatewayKit` with publishing and role-guard utilities so the binary can be launched directly via `swift run`.
+
+## OpenAPI specifications
+
+- Gateway surface: [`Packages/FountainSpecCuration/openapi/v1/gateway.yml`](../../../FountainSpecCuration/openapi/v1/gateway.yml)
+- Core plugins:
+  - Auth gateway: [`Packages/FountainSpecCuration/openapi/v1/auth-gateway.yml`](../../../FountainSpecCuration/openapi/v1/auth-gateway.yml)
+  - Curator gateway: [`Packages/FountainSpecCuration/openapi/v1/curator-gateway.yml`](../../../FountainSpecCuration/openapi/v1/curator-gateway.yml)
+  - LLM gateway: [`Packages/FountainSpecCuration/openapi/v1/llm-gateway.yml`](../../../FountainSpecCuration/openapi/v1/llm-gateway.yml)
+  - Rate limiter gateway: [`Packages/FountainSpecCuration/openapi/v1/rate-limiter-gateway.yml`](../../../FountainSpecCuration/openapi/v1/rate-limiter-gateway.yml)
+  - Role health check gateway: [`Packages/FountainSpecCuration/openapi/v1/role-health-check-gateway.yml`](../../../FountainSpecCuration/openapi/v1/role-health-check-gateway.yml)
+  - Payload inspection gateway: [`Packages/FountainSpecCuration/openapi/v1/payload-inspection-gateway.yml`](../../../FountainSpecCuration/openapi/v1/payload-inspection-gateway.yml)
+  - Budget breaker gateway: [`Packages/FountainSpecCuration/openapi/v1/budget-breaker-gateway.yml`](../../../FountainSpecCuration/openapi/v1/budget-breaker-gateway.yml)
+  - Destructive guardian gateway: [`Packages/FountainSpecCuration/openapi/v1/destructive-guardian-gateway.yml`](../../../FountainSpecCuration/openapi/v1/destructive-guardian-gateway.yml)
+  - Security sentinel gateway: [`Packages/FountainSpecCuration/openapi/v1/security-sentinel-gateway.yml`](../../../FountainSpecCuration/openapi/v1/security-sentinel-gateway.yml)
+
+These specs describe every HTTP contract the server exposes or invokes, replacing the legacy `openapi/` tree.
+
+## Key responsibilities
+
+- Load persona orchestration, publishing frontend assets, and rate limiting configuration from the environment or configuration store.
+- Wire gateway plugins (auth, curation, LLM, policy enforcement) together into a single `GatewayServer` instance.
+- Expose optional DNS emulation when launched with `--dns` for local testing.
+
+## Related packages
+
+- `FountainGatewayKit`: shared gateway plugins, orchestrator, and utilities referenced by this executable.
+- `PublishingFrontend`: static asset host embedded via `PublishingFrontendPlugin`.
+- `FountainSpecCuration`: authoritative OpenAPI specifications listed above.

--- a/Packages/FountainApps/Sources/persist-server/README.md
+++ b/Packages/FountainApps/Sources/persist-server/README.md
@@ -1,4 +1,4 @@
 # Persistence Service
 
-OpenAPI spec: [`openapi/v1/persist.yml`](../../openapi/v1/persist.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/persist.yml`](../../../FountainSpecCuration/openapi/v1/persist.yml)
 

--- a/Packages/FountainApps/Sources/planner-server/README.md
+++ b/Packages/FountainApps/Sources/planner-server/README.md
@@ -1,4 +1,4 @@
 # Planner Server
 
-OpenAPI spec: [`openapi/v1/planner.yml`](../../openapi/v1/planner.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/planner.yml`](../../../FountainSpecCuration/openapi/v1/planner.yml)
 

--- a/Packages/FountainApps/Sources/publishing-frontend/README.md
+++ b/Packages/FountainApps/Sources/publishing-frontend/README.md
@@ -1,0 +1,15 @@
+# Publishing Frontend
+
+`publishing-frontend` is a lightweight CLI that boots the static asset host used by the Gateway publishing plugin. It loads configuration from `PublishingFrontend` (in `FountainGatewayKit`) and serves HTML/JS bundles referenced by the Gateway UI routes.
+
+## API surface
+
+This executable does not expose its own REST API beyond the assets rendered by the Gateway. All HTTP contracts for publishing interactions are described by the Gateway specification at [`Packages/FountainSpecCuration/openapi/v1/gateway.yml`](../../../FountainSpecCuration/openapi/v1/gateway.yml).
+
+## Usage
+
+```bash
+swift run --package-path Packages/FountainApps publishing-frontend
+```
+
+Use `--help` or `--version` for CLI flags. Configuration is resolved from the standard `PublishingFrontend` configuration files and environment variables.

--- a/Packages/FountainApps/Sources/semantic-browser-server/README.md
+++ b/Packages/FountainApps/Sources/semantic-browser-server/README.md
@@ -11,7 +11,7 @@ A Swift service that fetches and renders web pages (with optional CDP headless b
 - Observability: Spec‑pure health, Prometheus metrics, admin diagnostics (browser pool, host gate, network capture, artifacts).
 
 ## API
-OpenAPI spec: [`openapi/v1/semantic-browser.yml`](../../openapi/v1/semantic-browser.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/semantic-browser.yml`](../../../FountainSpecCuration/openapi/v1/semantic-browser.yml)
 
 Key endpoints (spec‑compliant):
 - POST `/v1/snapshot` → SnapshotResponse
@@ -130,7 +130,7 @@ docker run --rm -p 8006:8006 \
 - Exports: check `ARTIFACT_ROOT` mount and permissions; review admin health for GC activity.
 
 ## Development
-- Specs live under `openapi/v1/semantic-browser.yml`.
+- Specs live under `Packages/FountainSpecCuration/openapi/v1/semantic-browser.yml`.
 - Unit tests under `Tests/SemanticBrowserTests/*` include spec conformance and query/index flows.
 - Run tests: `swift test -v`
 

--- a/Packages/FountainApps/Sources/tool-server/README.md
+++ b/Packages/FountainApps/Sources/tool-server/README.md
@@ -1,0 +1,21 @@
+# Tool Server
+
+The Tool Server executable exposes the curated Tool invocation API over HTTP. It delegates request handling to `ToolServerService` from `FountainServiceKit-ToolServer` and adds lightweight health and metrics endpoints for orchestration.
+
+## OpenAPI specification
+
+- Tool Server API: [`Packages/FountainSpecCuration/openapi/v1/tool-server.yml`](../../../FountainSpecCuration/openapi/v1/tool-server.yml)
+
+## Endpoints
+
+- `/_health` – JSON health probe used by dev tooling and orchestrators.
+- `/metrics` – Prometheus-style scrape for service liveness.
+- All other routes are defined in the OpenAPI document and handled by `ToolServerService`.
+
+## Running locally
+
+```bash
+swift run --package-path Packages/FountainApps tool-server
+```
+
+Set `PORT` to override the default `8012` listener.

--- a/Packages/FountainApps/Sources/tools-factory-server/README.md
+++ b/Packages/FountainApps/Sources/tools-factory-server/README.md
@@ -1,4 +1,4 @@
 # Tools Factory Server
 
-OpenAPI spec: [`openapi/v1/tools-factory.yml`](../../openapi/v1/tools-factory.yml)
+OpenAPI spec: [`Packages/FountainSpecCuration/openapi/v1/tools-factory.yml`](../../../FountainSpecCuration/openapi/v1/tools-factory.yml)
 

--- a/Packages/FountainApps/Sources/tutor-dashboard/EnvironmentLoader.swift
+++ b/Packages/FountainApps/Sources/tutor-dashboard/EnvironmentLoader.swift
@@ -30,7 +30,13 @@ struct DashboardConfiguration: Sendable {
             let overrideURL = URL(fileURLWithPath: overridePath, isDirectory: true, relativeTo: workingDirectory)
             rootURL = overrideURL.standardizedFileURL
         } else {
-            rootURL = workingDirectory.appendingPathComponent("openapi/v1", isDirectory: true)
+            let curatedRoot = workingDirectory.appendingPathComponent("Packages/FountainSpecCuration/openapi/v1", isDirectory: true)
+            var curatedIsDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: curatedRoot.path, isDirectory: &curatedIsDirectory), curatedIsDirectory.boolValue {
+                rootURL = curatedRoot
+            } else {
+                rootURL = workingDirectory.appendingPathComponent("openapi/v1", isDirectory: true)
+            }
         }
 
         var isDirectory: ObjCBool = false

--- a/Packages/FountainApps/Sources/tutor-dashboard/README.md
+++ b/Packages/FountainApps/Sources/tutor-dashboard/README.md
@@ -1,0 +1,19 @@
+# Tutor Dashboard CLI
+
+The Tutor Dashboard is a terminal UI that discovers Fountain services from their OpenAPI documents and polls each instance for health information. It ships as part of `FountainApps` so operators can inspect a local deployment from the command line.
+
+## OpenAPI discovery
+
+By default the dashboard scans [`Packages/FountainSpecCuration/openapi/v1`](../../../FountainSpecCuration/openapi/v1) for specs. Each service document declares discovery metadata (`x-fountain`) that drives the dashboard rows and health checks. Override the location with `--openapi-root <path>` or the `TUTOR_DASHBOARD_OPENAPI_ROOT` environment variable.
+
+## Environment and refresh configuration
+
+Set `TUTOR_DASHBOARD_ENV` to point at a `.env` file with service credentials. Refresh cadence can be tuned with `--refresh-interval` or `TUTOR_DASHBOARD_REFRESH_SECONDS`.
+
+## Running
+
+```bash
+swift run --package-path Packages/FountainApps tutor-dashboard
+```
+
+Use `--help` to see available flags. The dashboard exits cleanly with `q` and refreshes on demand with `r`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ FountainKit is the Swift Package Manager workspace that powers FountainAI for th
 
 Each package lives under `Packages/<Name>` with its own `Package.swift`, `Sources/`, `Tests/`, and `README`. The root manifest depends on these packages via relative paths for local development.
 
+## OpenAPI specifications
+
+Authoritative OpenAPI documents now live in [`Packages/FountainSpecCuration/openapi`](Packages/FountainSpecCuration/openapi). Service executables include README files that link directly to their specs (for example `Packages/FountainSpecCuration/openapi/v1/planner.yml`). Use this directory when regenerating clients or browsing HTTP contracts—the legacy root-level `openapi/` tree has been removed.
+
 ## Getting started
 
 ### Bootstrap the workspace


### PR DESCRIPTION
## Summary
- retargeted FountainApps service READMEs to the curated `Packages/FountainSpecCuration/openapi` specs and documented the new layout in the workspace README
- added README guides for gateway-server, tool-server, publishing-frontend, tutor-dashboard, and FountainLauncherUI along with a curated-spec default for the dashboard
- excluded the new documentation files from the package manifest to keep SwiftPM builds quiet

## Testing
- swift build --package-path Packages/FountainApps

------
https://chatgpt.com/codex/tasks/task_b_68d144af13948333b9a51f91f993d04b