### PR TITLE
Raise ToolServer macOS requirement to 14

### DIFF
--- a/Packages/FountainServiceKit-ToolServer/Package.swift
+++ b/Packages/FountainServiceKit-ToolServer/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "FountainServiceKit-ToolServer",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
         .library(name: "ToolServer", targets: ["ToolServer"]),


### PR DESCRIPTION
## Summary
- raise the FountainServiceKit-ToolServer package's macOS deployment target to 14 to match Toolsmith's minimum version

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68d20a66d4c48333b2a1a90512c49bd4