### PR TITLE
Raise macOS deployment target for tool server clients

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "FountainKit",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
         .library(name: "FountainKitWorkspace", targets: ["FountainKitWorkspace"])

--- a/Packages/FountainApps/Package.swift
+++ b/Packages/FountainApps/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "FountainApps",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
         .executable(name: "gateway-server", targets: ["gateway-server"]),

--- a/Packages/FountainServiceKit-ToolsFactory/Package.swift
+++ b/Packages/FountainServiceKit-ToolsFactory/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "FountainServiceKit-ToolsFactory",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     products: [
         .library(name: "ToolsFactoryService", targets: ["ToolsFactoryService"])


### PR DESCRIPTION
## Summary
- bump the FountainKit workspace package to require macOS 14 so it can depend on the ToolServer product
- raise the macOS deployment target for the Tools Factory service package to match its ToolServer dependency
- update FountainApps to build its executables against macOS 14 alongside the tool server runtime

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68d21350fca4833396a5ee73b8bec308